### PR TITLE
Remove A and D key navigation

### DIFF
--- a/js/ARCHITECTURE.md
+++ b/js/ARCHITECTURE.md
@@ -23,7 +23,7 @@ The game has been refactored from a single monolithic `GameScene.js` file into a
 - **`managers/AnimationManager.js`** - Static class for creating and managing Phaser animations
 - **`managers/BuildingManager.js`** - Handles building/environment sprite creation and positioning
 - **`managers/EnvironmentManager.js`** - Creates background, ground, and sky elements
-- **`managers/InputManager.js`** - Processes keyboard input and updates player state
+- **`managers/InputManager.js`** - Processes pointer input and updates player state
 
 ## Data Flow
 
@@ -38,7 +38,7 @@ main.js → GameScene → Managers/Components → Player/GameConfig
    - `PlayerSprite` creates player sprite with proper positioning
    - `AnimationManager` sets up sprite animations
    - `Sidebar` creates UI elements
-   - `InputManager` sets up keyboard controls
+   - `InputManager` sets up pointer controls
 
 3. **Game Loop**: `GameScene.update()` delegates to:
    - `InputManager.update()` processes input and updates player
@@ -79,7 +79,7 @@ main.js → GameScene → Managers/Components → Player/GameConfig
 - Updates position display in real-time
 
 ### InputManager
-- Processes A/D key input
+- Processes pointer input for player movement
 - Updates player movement state
 - Maintains boundary constraints
 - Updates sprite animations based on movement

--- a/js/GameConfig.js
+++ b/js/GameConfig.js
@@ -60,8 +60,8 @@ class GameConfig {
     };
 
     static SIDEBAR_CONTROLS_STYLE = {
-        fontSize: '12px',
-        fill: '#000000',
+        fontSize: '11px',
+        fill: '#2c3e50',
         fontFamily: 'monospace'
     };
 

--- a/js/GameConfig.js
+++ b/js/GameConfig.js
@@ -44,8 +44,6 @@ class GameConfig {
     static SIDEBAR_MARGIN = GameConfig.WINDOW_WIDTH + 20;
     static SIDEBAR_PLAYER_Y = 30;
     static SIDEBAR_CONTROLS_Y = 80;
-    static SIDEBAR_KEY_A_Y = 120;
-    static SIDEBAR_KEY_D_Y = 155;
 
     // Sidebar text styles
     static SIDEBAR_PLAYER_STYLE = {
@@ -61,26 +59,10 @@ class GameConfig {
         fontFamily: 'monospace'
     };
 
-    // Sidebar key configuration
-    static SIDEBAR_KEY_CONFIG = {
-        x: GameConfig.WINDOW_WIDTH + 30,
-        size: 20,
-        borderWidth: 4,
-        borderColor: 0x000000,
-        bgColor: 0xffffff,
-        textOffset: 6,
-        labelOffset: 25,
-        textStyle: { 
-            fontSize: '14px', 
-            fill: '#000000', 
-            fontFamily: 'monospace', 
-            fontWeight: 'bold' 
-        },
-        labelStyle: { 
-            fontSize: '12px', 
-            fill: '#000000', 
-            fontFamily: 'monospace' 
-        }
+    static SIDEBAR_CONTROLS_STYLE = {
+        fontSize: '12px',
+        fill: '#000000',
+        fontFamily: 'monospace'
     };
 
     // Animation frame configuration

--- a/js/components/Sidebar.js
+++ b/js/components/Sidebar.js
@@ -68,6 +68,7 @@ class Sidebar {
                 fontFamily: 'monospace'
             }
         );
+        this.positionText.setStyle({ textDecoration: 'none' });
         this.elements.push(this.positionText);
     }
 
@@ -81,14 +82,45 @@ class Sidebar {
         );
         this.elements.push(this.controlsHeader);
 
-        // Create controls text
-        this.controlsText = this.scene.add.text(
-            GameConfig.SIDEBAR_MARGIN,
-            GameConfig.SIDEBAR_CONTROLS_Y + 30,
-            "Left Click: Move Player\nRight Click: Select Player",
+        // Create mouse icon with controls
+        const controlsY = GameConfig.SIDEBAR_CONTROLS_Y + 25;
+        
+        // Left click control
+        this.leftClickIcon = this.scene.add.graphics();
+        this.leftClickIcon.fillStyle(0x000000, 1);
+        this.leftClickIcon.fillRoundedRect(GameConfig.SIDEBAR_MARGIN, controlsY, 18, 20, 3);
+        this.leftClickIcon.fillStyle(0xffffff, 1);
+        this.leftClickIcon.fillRect(GameConfig.SIDEBAR_MARGIN + 2, controlsY + 2, 7, 10);
+        this.leftClickIcon.lineStyle(1, 0x000000, 1);
+        this.leftClickIcon.strokeRect(GameConfig.SIDEBAR_MARGIN + 2, controlsY + 2, 7, 10);
+        this.elements.push(this.leftClickIcon);
+        
+        this.leftClickText = this.scene.add.text(
+            GameConfig.SIDEBAR_MARGIN + 25,
+            controlsY + 2,
+            "Move Player",
             GameConfig.SIDEBAR_CONTROLS_STYLE
         );
-        this.elements.push(this.controlsText);
+        this.elements.push(this.leftClickText);
+        
+        // Right click control
+        const rightClickY = controlsY + 30;
+        this.rightClickIcon = this.scene.add.graphics();
+        this.rightClickIcon.fillStyle(0x000000, 1);
+        this.rightClickIcon.fillRoundedRect(GameConfig.SIDEBAR_MARGIN, rightClickY, 18, 20, 3);
+        this.rightClickIcon.fillStyle(0xffffff, 1);
+        this.rightClickIcon.fillRect(GameConfig.SIDEBAR_MARGIN + 9, rightClickY + 2, 7, 10);
+        this.rightClickIcon.lineStyle(1, 0x000000, 1);
+        this.rightClickIcon.strokeRect(GameConfig.SIDEBAR_MARGIN + 9, rightClickY + 2, 7, 10);
+        this.elements.push(this.rightClickIcon);
+        
+        this.rightClickText = this.scene.add.text(
+            GameConfig.SIDEBAR_MARGIN + 25,
+            rightClickY + 2,
+            "Select Player",
+            GameConfig.SIDEBAR_CONTROLS_STYLE
+        );
+        this.elements.push(this.rightClickText);
     }
 
 

--- a/js/components/Sidebar.js
+++ b/js/components/Sidebar.js
@@ -68,7 +68,6 @@ class Sidebar {
                 fontFamily: 'monospace'
             }
         );
-        this.positionText.setStyle({ textDecoration: 'none' });
         this.elements.push(this.positionText);
     }
 

--- a/js/components/Sidebar.js
+++ b/js/components/Sidebar.js
@@ -81,46 +81,17 @@ class Sidebar {
         );
         this.elements.push(this.controlsHeader);
 
-        // Create key controls
-        this.createKeyControl('A', 'Move Left', GameConfig.SIDEBAR_KEY_A_Y);
-        this.createKeyControl('D', 'Move Right', GameConfig.SIDEBAR_KEY_D_Y);
+        // Create controls text
+        this.controlsText = this.scene.add.text(
+            GameConfig.SIDEBAR_MARGIN,
+            GameConfig.SIDEBAR_CONTROLS_Y + 30,
+            "Left Click: Move Player\nRight Click: Select Player",
+            GameConfig.SIDEBAR_CONTROLS_STYLE
+        );
+        this.elements.push(this.controlsText);
     }
 
-    createKeyControl(key, label, y) {
-        const keyConfig = GameConfig.SIDEBAR_KEY_CONFIG;
-        
-        // Key background and border
-        const keyBorder = this.scene.add.rectangle(
-            keyConfig.x, y, 
-            keyConfig.size + keyConfig.borderWidth, 
-            keyConfig.size + keyConfig.borderWidth, 
-            keyConfig.borderColor
-        );
-        
-        const keyBg = this.scene.add.rectangle(
-            keyConfig.x, y, 
-            keyConfig.size, keyConfig.size, 
-            keyConfig.bgColor
-        );
 
-        // Key letter
-        const keyText = this.scene.add.text(
-            keyConfig.x - keyConfig.textOffset, 
-            y - keyConfig.textOffset, 
-            key, 
-            keyConfig.textStyle
-        );
-
-        // Label
-        const labelText = this.scene.add.text(
-            keyConfig.x + keyConfig.labelOffset, 
-            y - keyConfig.textOffset, 
-            label, 
-            keyConfig.labelStyle
-        );
-
-        this.elements.push(keyBorder, keyBg, keyText, labelText);
-    }
 
     updatePlayer(_player)
     {


### PR DESCRIPTION
Remove A/D key navigation UI and related configuration as they are no longer used and the game relies on pointer input.

The A/D key input was already disabled in the game's core logic, but the sidebar still displayed these controls, creating a misleading user experience. This PR cleans up these unused UI elements, removes obsolete configuration, and updates documentation to accurately reflect the game's pointer-based navigation.