### PR TITLE
Move John Sim to ground floor by default

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -163,7 +163,7 @@ createFloorWalls() {
     this.players = [];
 
     const playerConfigs = [
-        { name: ['John', 'Sim'], floor: 3, sprite: 'npc1' },
+        { name: ['John', 'Sim'], floor: 0, sprite: 'npc1' },
         { name: ['Alice', 'Lee'], floor: 2, sprite: 'npc2' },
          { name: ['Alice2', 'Lee2'], floor: 1, sprite: 'npc2' },
     ];


### PR DESCRIPTION
Set John Sim's default spawn floor to the ground floor.