### PR TITLE
Rename character using new sprite sheet

### DIFF
--- a/js/GameScene.js
+++ b/js/GameScene.js
@@ -21,6 +21,11 @@ class GameScene extends Phaser.Scene {
             frameHeight: GameConfig.SPRITE_HEIGHT
         });
 
+        this.load.spritesheet('npc3', 'NPC/Female/NPC 3.png', {
+            frameWidth: GameConfig.SPRITE_WIDTH,
+            frameHeight: GameConfig.SPRITE_HEIGHT
+        });
+
         // Load building sprites
         this.load.image('lobby', 'World/apartment_lobby.png');
         this.load.image('design1', 'World/apartment_design1.png');
@@ -165,7 +170,7 @@ createFloorWalls() {
     const playerConfigs = [
         { name: ['John', 'Sim'], floor: 3, sprite: 'npc1' },
         { name: ['Alice', 'Lee'], floor: 2, sprite: 'npc2' },
-         { name: ['Alice2', 'Lee2'], floor: 1, sprite: 'npc2' },
+         { name: ['Sarah', 'Johnson'], floor: 1, sprite: 'npc3' },
     ];
 
     // Track unique sprite keys to avoid duplicate animation creation


### PR DESCRIPTION
Rename 'Alice2 Lee2' to 'Sarah Johnson' and assign a unique NPC sprite to differentiate her from 'Alice Lee'.

This change addresses the previous duplication where 'Alice2 Lee2' shared the same name and sprite as 'Alice Lee', providing distinct identities for both characters.